### PR TITLE
add Ada hello world example

### DIFF
--- a/doc/src_fsfw-user_config/FSFW-Material/hello-world-collection/Ada/01_hello_world/hello_world.gpr
+++ b/doc/src_fsfw-user_config/FSFW-Material/hello-world-collection/Ada/01_hello_world/hello_world.gpr
@@ -1,0 +1,6 @@
+project Hello_World is
+
+    for Source_Dirs use ("src");
+    for Main use ("hello_world.adb");
+
+end Hello_World;

--- a/doc/src_fsfw-user_config/FSFW-Material/hello-world-collection/Ada/01_hello_world/src/hello_world.adb
+++ b/doc/src_fsfw-user_config/FSFW-Material/hello-world-collection/Ada/01_hello_world/src/hello_world.adb
@@ -1,0 +1,8 @@
+
+with Ada.Text_Io;
+
+procedure Hello_World
+is
+begin
+    Ada.Text_Io.Put_Line ("Hello world from Ada!");
+end Hello_World;

--- a/doc/src_fsfw-user_config/FSFW-Material/hello-world-collection/Ada/README.md
+++ b/doc/src_fsfw-user_config/FSFW-Material/hello-world-collection/Ada/README.md
@@ -1,0 +1,13 @@
+# Overview
+
+This directory contains some examples of the Ada language.
+
+Ada is a strongly typed language designed for high integrity and safety. It is used among others in the avionics and aerospace sector and for railway signalling.
+
+Examples:
+
+- 01_hello_world:
+  - run `gprbuild -P hello_world.gpr` to compile
+  - run `./hello_world` to run the program
+  - run `gprclean -P hello_world.gpr` to clean the directory
+

--- a/doc/src_fsfw-user_config/FSFW-Material/hello-world-collection/README.md
+++ b/doc/src_fsfw-user_config/FSFW-Material/hello-world-collection/README.md
@@ -4,8 +4,9 @@ This repository collects material which aims to make it easier to get started wi
 Currently the following languages are covered (see README.md files in each directory):
 
 * [Python](python/README.md)
-* [C](python/README.md)
-* [Go](python/README.md)
+* [C](C/README.md)
+* [Go](go/README.md)
+* [Ada](Ada/README.md)
 
 **Note**: You can use the command `grip` to render markdown files (like this one).
 


### PR DESCRIPTION
Ich habe wie im letzten Plenum besprochen mal ein Hello World für Ada geschrieben. Ich hatte überlegt auch noch ein Beispiel für SPARK hinzuzufügen aber um das wirklich ausnutzen zu können bräuchte man die SPARK Toolchain mit gnatprove die nicht für Debian gepackaged (aber auch GPL-lizensiert von Adacore verfügbar, sollte man dann aber mit dem GNAT von Adacore verwenden und das ist zusammen ca. 2GB groß) ist. 