### PR TITLE
Link auf alte Paketliste aktualisiert

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -106,7 +106,7 @@ Genauer gesagt ist unter anderem folgendes auf dem Stick drauf:
 [enigmail]: https://www.enigmail.net/index.php/en/
 [zim]: http://zim-wiki.org/
 
-Insgesamt sind noch viel mehr Programme im Live-System installiert ([vollständige Paketliste](https://github.com/fsfw-dresden/usb-live-linux/blob/master/config/FSFW-Uni-Stick_KDE_jessie_amd64/doc/FSFW-Uni-Stick_-_Paketliste.md)).
+Insgesamt sind noch viel mehr Programme im Live-System installiert ([vollständige Paketliste](https://github.com/fsfw-dresden/usb-live-linux/blob/master/doc/FSFW-Uni-Stick_-_Paketliste.md)).
 Aber auch wenn ihr unter Windows arbeiten wollt/müsst, kann euch
 dieser Stick nützlich sein: auf ihm findet ihr ebenfalls eine [→große Auswahl](windows.md)
 an freien Programmen, die unter Windows laufen.


### PR DESCRIPTION
Der Link auf die Jessie-Paketliste ist doch etwas überholt. Deshalb nun auf doc/FSFW-Uni-Stick_-_Paketliste.md (im Masterbranch).