### PR TITLE
Openstreetmap-Tools

### DIFF
--- a/variants/FSFW-Uni-Stick_KDE_stretch_amd64/paketlisten/education.md
+++ b/variants/FSFW-Uni-Stick_KDE_stretch_amd64/paketlisten/education.md
@@ -20,10 +20,10 @@
 - ###  geography
 
 - :x:  marble  --	Schreibtischglobus mit Routingfunktion (über Pluginsystem erweiterbar)
-- :o:  josm  --		OpenStreetmap-Editor
+- :x:  josm  --		OpenStreetmap-Editor
 
 [//]: # (Hat sich nicht so richtig bewähren können)
-- :o:  gosmore  -- OpenStreetmap-Frontend (Viewer mit Sprachausgabe)
+- :x:  gosmore  -- OpenStreetmap-Frontend (Viewer mit Sprachausgabe)
 
 - ###  astronomy
 


### PR DESCRIPTION
Zwei bisher als empfohlen vermerkte Geo-Programme testweise aus installieren gesetzt.

Test ausstehend.