### PR TITLE
Weiche Abhängigkeit für Spyder ergänzt

### DIFF
--- a/variants/FSFW-Uni-Stick_KDE_stretch_amd64/paketlisten/programmieren-ide.md
+++ b/variants/FSFW-Uni-Stick_KDE_stretch_amd64/paketlisten/programmieren-ide.md
@@ -23,6 +23,7 @@
 - :o:  eric  -- Vollständige integrierte Python-Entwicklungsumgebung
 - :+1:  spyder  -- Python-IDE für Wissenschaftler (Python 2)
 - :x:  spyder3  -- Python-IDE für Wissenschaftler (Python 3)
+- :x:  python-rope -- Empfehlung von Spyder3 (Python refactoring library )
 
 - :o:  qtcreator  -- IDE für C++ incl. QT-Framework
 


### PR DESCRIPTION
Die Python-IDE Spyder(3) macht mit der Programmierbibliothek python(3)-rope mehr Sinn.